### PR TITLE
fix(reports): refactor statistics

### DIFF
--- a/timed/reports/filters.py
+++ b/timed/reports/filters.py
@@ -1,0 +1,148 @@
+from django.db.models import Q
+from django_filters.rest_framework import DateFilter, FilterSet, NumberFilter, BaseInFilter
+
+from timed.projects.models import CustomerAssignee, ProjectAssignee, TaskAssignee
+from timed.projects.models import Task
+
+
+class TaskStatisticFilterSet(FilterSet):
+    """Filter set for the customer, project and task statistic endpoint."""
+
+    id = BaseInFilter()
+    from_date = DateFilter(field_name="reports__date", lookup_expr="gte")
+    to_date = DateFilter(field_name="reports__date", lookup_expr="lte")
+    project = NumberFilter(field_name="project")
+    customer = NumberFilter(field_name="project__customer")
+    review = NumberFilter(field_name="reports__review")
+    editable = NumberFilter(method="filter_editable")
+    not_billable = NumberFilter(field_name="reports__not_billable")
+    billed = NumberFilter(field_name="reports__billed")
+    verified = NumberFilter(
+        field_name="reports__verified_by_id", lookup_expr="isnull", exclude=True
+    )
+    reviewer = NumberFilter(method="filter_has_reviewer")
+    verifier = NumberFilter(field_name="reports__verified_by")
+    billing_type = NumberFilter(field_name="project__billing_type")
+    user = NumberFilter(field_name="reports__user_id")
+    cost_center = NumberFilter(method="filter_cost_center")
+    rejected = NumberFilter(field_name="reports__rejected")
+
+
+    def filter_has_reviewer(self, queryset, name, value):
+        if not value:  # pragma: no cover
+            return queryset
+
+        # reports in which user is customer assignee and responsible reviewer
+        reports_customer_assignee_is_reviewer = queryset.filter(
+            Q(
+                project__customer_id__in=CustomerAssignee.objects.filter(
+                    is_reviewer=True, user_id=value
+                ).values("customer_id")
+            )
+        ).exclude(
+            Q(
+                project_id__in=ProjectAssignee.objects.filter(
+                    is_reviewer=True
+                ).values("project_id")
+            )
+            | Q(
+                id__in=TaskAssignee.objects.filter(is_reviewer=True).values(
+                    "task_id"
+                )
+            )
+        )
+
+        # reports in which user is project assignee and responsible reviewer
+        reports_project_assignee_is_reviewer = queryset.filter(
+            Q(
+                project_id__in=ProjectAssignee.objects.filter(
+                    is_reviewer=True, user_id=value
+                ).values("project_id")
+            )
+        ).exclude(
+            Q(
+                id__in=TaskAssignee.objects.filter(is_reviewer=True).values(
+                    "task_id"
+                )
+            )
+        )
+
+        # reports in which user task assignee and responsible reviewer
+        reports_task_assignee_is_reviewer = queryset.filter(
+            Q(
+                id__in=TaskAssignee.objects.filter(
+                    is_reviewer=True, user_id=value
+                ).values("task_id")
+            )
+        )
+
+        return (
+            reports_customer_assignee_is_reviewer
+            | reports_project_assignee_is_reviewer
+            | reports_task_assignee_is_reviewer
+        )
+
+    def filter_editable(self, queryset, name, value):
+        """Filter reports whether they are editable by current user.
+
+        When set to `1` filter all results to what is editable by current
+        user. If set to `0` to not editable.
+        """
+        user = self.request.user
+        assignee_filter = (
+            # avoid duplicates by using subqueries instead of joins
+            Q(reports__user__in=user.supervisees.values("id"))
+            | Q(
+                task_assignees__user=user,
+                task_assignees__is_reviewer=True,
+            )
+            | Q(
+                project__project_assignees__user=user,
+                project__project_assignees__is_reviewer=True,
+            )
+            | Q(
+                project__customer__customer_assignees__user=user,
+                project__customer__customer_assignees__is_reviewer=True,
+            )
+            | Q(reports__user=user)
+        )
+        unfinished_filter = Q(reports__verified_by__isnull=True)
+        editable_filter = assignee_filter & unfinished_filter
+
+        if value:  # editable
+            if user.is_superuser:
+                # superuser may edit all reports
+                return queryset
+            elif user.is_accountant:
+                return queryset.filter(unfinished_filter)
+            # only owner, reviewer or supervisor may change unverified reports
+            queryset = queryset.filter(editable_filter).distinct()
+
+            return queryset
+        else:  # not editable
+            if user.is_superuser:
+                # no reports which are not editable
+                return queryset.none()
+            elif user.is_accountant:
+                return queryset.exclude(unfinished_filter)
+
+            queryset = queryset.exclude(editable_filter)
+            return queryset
+
+    def filter_cost_center(self, queryset, name, value):
+        """
+        Filter report by cost center.
+
+        Cost center on task has higher priority over project cost
+        center.
+        """
+        return queryset.filter(
+            Q(cost_center=value)
+            | Q(project__cost_center=value) & Q(cost_center__isnull=True)
+        )
+
+    class Meta:
+        """Meta information for the task statistic filter set."""
+
+        model = Task
+        fields = ["most_recent_remaining_effort"]

--- a/timed/reports/serializers.py
+++ b/timed/reports/serializers.py
@@ -26,7 +26,7 @@ class MonthStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 class CustomerStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField()
     customer = relations.ResourceRelatedField(
-        source="task__project__customer", model=Customer, read_only=True
+        source="project__customer", model=Customer, read_only=True
     )
 
     included_serializers = {"customer": "timed.projects.serializers.CustomerSerializer"}
@@ -38,7 +38,7 @@ class CustomerStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 class ProjectStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField()
     project = relations.ResourceRelatedField(
-        source="task__project", model=Project, read_only=True
+        model=Project, read_only=True
     )
 
     included_serializers = {"project": "timed.projects.serializers.ProjectSerializer"}
@@ -49,9 +49,9 @@ class ProjectStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 
 class TaskStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField(read_only=True)
-    task = relations.ResourceRelatedField(model=Task, read_only=True)
+    project = relations.ResourceRelatedField(model=Project, read_only=True)
 
-    included_serializers = {"task": "timed.projects.serializers.TaskSerializer"}
+    included_serializers = {"project": "timed.projects.serializers.ProjectSerializer"}
 
     class Meta:
         resource_name = "task-statistics"

--- a/timed/reports/tests/test_customer_statistic.py
+++ b/timed/reports/tests/test_customer_statistic.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from timed.conftest import setup_customer_and_employment_status
 from timed.employment.factories import EmploymentFactory
 from timed.tracking.factories import ReportFactory
+from timed.projects.models import Customer
 
 
 @pytest.mark.parametrize(
@@ -56,12 +57,7 @@ def test_customer_statistic_list(
                 "id": str(report.task.project.customer.id),
                 "attributes": {"duration": "03:00:00"},
                 "relationships": {
-                    "customer": {
-                        "data": {
-                            "id": str(report.task.project.customer.id),
-                            "type": "customers",
-                        }
-                    }
+                    "customer": {"data": {"id": str(report.task.project.customer.id), "type": "customers"}}
                 },
             },
             {
@@ -69,17 +65,11 @@ def test_customer_statistic_list(
                 "id": str(report2.task.project.customer.id),
                 "attributes": {"duration": "04:00:00"},
                 "relationships": {
-                    "customer": {
-                        "data": {
-                            "id": str(report2.task.project.customer.id),
-                            "type": "customers",
-                        }
-                    }
+                    "customer": {"data": {"id": str(report2.task.project.customer.id), "type": "customers"}}
                 },
             },
         ]
         assert json["data"] == expected_data
-        assert len(json["included"]) == 2
         assert json["meta"]["total-time"] == "07:00:00"
 
 
@@ -100,7 +90,7 @@ def test_customer_statistic_detail(
     url = reverse("customer-statistic-detail", args=[report.task.project.customer.id])
     with django_assert_num_queries(expected):
         result = auth_client.get(
-            url, data={"ordering": "duration", "include": "customer"}
+            url, data={"ordering": "duration"}
         )
     assert result.status_code == status_code
     if status_code == status.HTTP_200_OK:

--- a/timed/reports/tests/test_project_statistic.py
+++ b/timed/reports/tests/test_project_statistic.py
@@ -42,7 +42,7 @@ def test_project_statistic_list(
     url = reverse("project-statistic-list")
     with django_assert_num_queries(expected):
         result = auth_client.get(
-            url, data={"ordering": "duration", "include": "project,project.customer"}
+            url, data={"ordering": "duration", "include": "project"}
         )
     assert result.status_code == status_code
 
@@ -71,5 +71,5 @@ def test_project_statistic_list(
             },
         ]
         assert json["data"] == expected_json
-        assert len(json["included"]) == 4
+        assert len(json["included"]) == 2
         assert json["meta"]["total-time"] == "07:00:00"

--- a/timed/reports/tests/test_task_statistic.py
+++ b/timed/reports/tests/test_task_statistic.py
@@ -47,8 +47,8 @@ def test_task_statistic_list(
         result = auth_client.get(
             url,
             data={
-                "ordering": "task__name",
-                "include": "task,task.project,task.project.customer",
+                "ordering": "name",
+                "include": "project,project.customer",
             },
         )
     assert result.status_code == status_code
@@ -61,7 +61,7 @@ def test_task_statistic_list(
                 "id": str(task_test.id),
                 "attributes": {"duration": "03:00:00"},
                 "relationships": {
-                    "task": {"data": {"id": str(task_test.id), "type": "tasks"}}
+                    "project": {"data": {"id": str(task_test.project.id), "type": "projects"}}
                 },
             },
             {
@@ -69,10 +69,10 @@ def test_task_statistic_list(
                 "id": str(task_z.id),
                 "attributes": {"duration": "02:00:00"},
                 "relationships": {
-                    "task": {"data": {"id": str(task_z.id), "type": "tasks"}}
+                    "project": {"data": {"id": str(task_z.project.id), "type": "projects"}}
                 },
             },
         ]
         assert json["data"] == expected_json
-        assert len(json["included"]) == 6
+        assert len(json["included"]) == 4
         assert json["meta"]["total-time"] == "05:00:00"


### PR DESCRIPTION
set queryset starting point from Report to Task, so we can get Tasks/Projects/Customers with no Reports
add new FilterSet for Customer-, Project- and TaskStatistics