### PR TITLE
feat(filters): allow filtering of tasks and reports in statistics

### DIFF
--- a/timed/employment/admin.py
+++ b/timed/employment/admin.py
@@ -4,6 +4,7 @@ import datetime
 
 from django import forms
 from django.contrib import admin
+from django.contrib.admin.widgets import AutocompleteSelect
 from django.contrib.auth.admin import UserAdmin
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
@@ -21,7 +22,11 @@ class SupervisorForm(forms.ModelForm):
 
     # Change the label of the supervisor through table attribute to_user
     to_user = forms.ModelChoiceField(
-        queryset=models.User.objects.all(), label=_("supervised by")
+        queryset=models.User.objects.all(),
+        label=_("supervised by"),
+        widget=AutocompleteSelect(
+            models.User.supervisors.through.to_user.field, admin_site=admin.site
+        ),
     )
 
     class Meta:
@@ -36,7 +41,11 @@ class SuperviseeForm(forms.ModelForm):
 
     # Change the label of the supervisor through table attribute from_user
     from_user = forms.ModelChoiceField(
-        queryset=models.User.objects.all(), label=_("supervising")
+        queryset=models.User.objects.all(),
+        label=_("supervising"),
+        widget=AutocompleteSelect(
+            models.User.supervisors.through.from_user.field, admin_site=admin.site
+        ),
     )
 
     class Meta:
@@ -47,6 +56,7 @@ class SuperviseeForm(forms.ModelForm):
 
 
 class SupervisorInline(admin.TabularInline):
+    autocomplete_fields = ["to_user"]
     form = SupervisorForm
     model = models.User.supervisors.through
     extra = 0
@@ -56,6 +66,7 @@ class SupervisorInline(admin.TabularInline):
 
 
 class SuperviseeInline(admin.TabularInline):
+    autocomplete_fields = ["from_user"]
     form = SuperviseeForm
     model = models.User.supervisors.through
     extra = 0
@@ -143,6 +154,7 @@ class UserAdmin(UserAdmin):
         AbsenceCreditInline,
     ]
     list_display = ("username", "first_name", "last_name", "is_staff", "is_active")
+    search_fields = ["username"]
 
     actions = [
         "disable_users",

--- a/timed/employment/filters.py
+++ b/timed/employment/filters.py
@@ -46,6 +46,10 @@ class UserFilterSet(FilterSet):
     is_reviewer = NumberFilter(method="filter_is_reviewer")
     is_supervisor = NumberFilter(method="filter_is_supervisor")
     is_accountant = NumberFilter(field_name="is_accountant")
+    is_external = NumberFilter(method="filter_is_external")
+
+    def filter_is_external(self, queryset, name, value):
+        return queryset.filter(employments__is_external=value)
 
     def filter_is_reviewer(self, queryset, name, value):
         if value:

--- a/timed/employment/tests/test_user.py
+++ b/timed/employment/tests/test_user.py
@@ -205,6 +205,21 @@ def test_user_transfer(superadmin_client):
     assert absence_credit.comment == "Transfer 2017"
 
 
+@pytest.mark.parametrize("value,expected", [(1, 2), (0, 2)])
+def test_user_is_external_filter(internal_employee_client, value, expected):
+    """Should filter users if they have an internal employment."""
+    user = UserFactory.create()
+    user2, user3 = UserFactory.create_batch(2)
+    EmploymentFactory.create(is_external=False, user=user)
+    EmploymentFactory.create(is_external=True, user=user2)
+    EmploymentFactory.create(is_external=True, user=user3)
+
+    response = internal_employee_client.get(
+        reverse("user-list"), {"is_external": value}
+    )
+    assert len(response.json()["data"]) == expected
+
+
 @pytest.mark.parametrize("value,expected", [(1, 1), (0, 4)])
 def test_user_is_reviewer_filter(internal_employee_client, value, expected):
     """Should filter users if they are a reviewer."""

--- a/timed/projects/admin.py
+++ b/timed/projects/admin.py
@@ -13,16 +13,19 @@ from timed.subscription.admin import CustomerPasswordInline
 
 
 class CustomerAssigneeInline(admin.TabularInline):
+    autocomplete_fields = ["user"]
     model = models.CustomerAssignee
     extra = 0
 
 
 class ProjectAssigneeInline(NestedStackedInline):
+    autocomplete_fields = ["user"]
     model = models.ProjectAssignee
     extra = 0
 
 
 class TaskAssigneeInline(NestedStackedInline):
+    autocomplete_fields = ["user"]
     model = models.TaskAssignee
     extra = 1
 

--- a/timed/reports/filters.py
+++ b/timed/reports/filters.py
@@ -5,7 +5,14 @@ from timed.projects.models import CustomerAssignee, ProjectAssignee, TaskAssigne
 from timed.projects.models import Task
 
 
-class TaskStatisticFilterSet(FilterSet):
+class MultiQSFilterMixin():
+    def filter_queryset(self, queryset):
+        qs = super().filter_queryset(queryset)
+        return qs._finalize()
+
+
+
+class TaskStatisticFilterSet(MultiQSFilterMixin, FilterSet):
     """Filter set for the customer, project and task statistic endpoint."""
 
     id = BaseInFilter()
@@ -140,6 +147,7 @@ class TaskStatisticFilterSet(FilterSet):
             Q(cost_center=value)
             | Q(project__cost_center=value) & Q(cost_center__isnull=True)
         )
+
 
     class Meta:
         """Meta information for the task statistic filter set."""

--- a/timed/reports/filters.py
+++ b/timed/reports/filters.py
@@ -1,0 +1,148 @@
+from django.db.models import Q
+from django_filters.rest_framework import DateFilter, FilterSet, NumberFilter, BaseInFilter
+
+from timed.projects.models import CustomerAssignee, ProjectAssignee, TaskAssignee
+from timed.projects.models import Task
+
+
+class TaskStatisticFilterSet(FilterSet):
+    """Filter set for the customer, project and task statistic endpoint."""
+
+    id = BaseInFilter()
+    from_date = DateFilter(field_name="reports__date", lookup_expr="gte")
+    to_date = DateFilter(field_name="reports__date", lookup_expr="lte")
+    project = NumberFilter(field_name="project")
+    customer = NumberFilter(field_name="project__customer")
+    review = NumberFilter(field_name="reports__review")
+    editable = NumberFilter(method="filter_editable")
+    not_billable = NumberFilter(field_name="reports__not_billable")
+    billed = NumberFilter(field_name="reports__billed")
+    verified = NumberFilter(
+        field_name="reports__verified_by_id", lookup_expr="isnull", exclude=True
+    )
+    reviewer = NumberFilter(method="filter_has_reviewer")
+    verifier = NumberFilter(field_name="reports__verified_by")
+    billing_type = NumberFilter(field_name="project__billing_type")
+    user = NumberFilter(field_name="reports__user_id")
+    cost_center = NumberFilter(method="filter_cost_center")
+    rejected = NumberFilter(field_name="reports__rejected")
+
+
+    def filter_has_reviewer(self, queryset, name, value):
+        if not value:  # pragma: no cover
+            return queryset
+
+        # reports in which user is customer assignee and responsible reviewer
+        reports_customer_assignee_is_reviewer = queryset.filter(
+            Q(
+                project__customer_id__in=CustomerAssignee.objects.filter(
+                    is_reviewer=True, user_id=value
+                ).values("customer_id")
+            )
+        ).exclude(
+            Q(
+                project_id__in=ProjectAssignee.objects.filter(
+                    is_reviewer=True
+                ).values("project_id")
+            )
+            | Q(
+                id__in=TaskAssignee.objects.filter(is_reviewer=True).values(
+                    "task_id"
+                )
+            )
+        )
+
+        # reports in which user is project assignee and responsible reviewer
+        reports_project_assignee_is_reviewer = queryset.filter(
+            Q(
+                project_id__in=ProjectAssignee.objects.filter(
+                    is_reviewer=True, user_id=value
+                ).values("project_id")
+            )
+        ).exclude(
+            Q(
+                id__in=TaskAssignee.objects.filter(is_reviewer=True).values(
+                    "task_id"
+                )
+            )
+        )
+
+        # reports in which user task assignee and responsible reviewer
+        reports_task_assignee_is_reviewer = queryset.filter(
+            Q(
+                id__in=TaskAssignee.objects.filter(
+                    is_reviewer=True, user_id=value
+                ).values("task_id")
+            )
+        )
+
+        return (
+            reports_customer_assignee_is_reviewer
+            | reports_project_assignee_is_reviewer
+            | reports_task_assignee_is_reviewer
+        )
+
+    def filter_editable(self, queryset, name, value):
+        """Filter reports whether they are editable by current user.
+
+        When set to `1` filter all results to what is editable by current
+        user. If set to `0` to not editable.
+        """
+        user = self.request.user
+        assignee_filter = (
+            # avoid duplicates by using subqueries instead of joins
+            Q(reports__user__in=user.supervisees.values("id"))
+            | Q(
+                task_assignees__user=user,
+                task_assignees__is_reviewer=True,
+            )
+            | Q(
+                project__project_assignees__user=user,
+                project__project_assignees__is_reviewer=True,
+            )
+            | Q(
+                project__customer__customer_assignees__user=user,
+                project__customer__customer_assignees__is_reviewer=True,
+            )
+            | Q(reports__user=user)
+        )
+        unfinished_filter = Q(reports__verified_by__isnull=True)
+        editable_filter = assignee_filter & unfinished_filter
+
+        if value:  # editable
+            if user.is_superuser:
+                # superuser may edit all reports
+                return queryset
+            elif user.is_accountant:
+                return queryset.filter(unfinished_filter)
+            # only owner, reviewer or supervisor may change unverified reports
+            queryset = queryset.filter(editable_filter).distinct()
+
+            return queryset
+        else:  # not editable
+            if user.is_superuser:
+                # no reports which are not editable
+                return queryset.none()
+            elif user.is_accountant:
+                return queryset.exclude(unfinished_filter)
+
+            queryset = queryset.exclude(editable_filter)
+            return queryset
+
+    def filter_cost_center(self, queryset, name, value):
+        """
+        Filter report by cost center.
+
+        Cost center on task has higher priority over project cost
+        center.
+        """
+        return queryset.filter(
+            Q(cost_center=value)
+            | Q(project__cost_center=value) & Q(cost_center__isnull=True)
+        )
+
+    class Meta:
+        """Meta information for the task statistic filter set."""
+
+        model = Task
+        fields = ["most_recent_remaining_effort"]

--- a/timed/reports/filters.py
+++ b/timed/reports/filters.py
@@ -1,15 +1,18 @@
 from django.db.models import Q
-from django_filters.rest_framework import DateFilter, FilterSet, NumberFilter, BaseInFilter
+from django_filters.rest_framework import (
+    BaseInFilter,
+    DateFilter,
+    FilterSet,
+    NumberFilter,
+)
 
-from timed.projects.models import CustomerAssignee, ProjectAssignee, TaskAssignee
-from timed.projects.models import Task
+from timed.projects.models import CustomerAssignee, ProjectAssignee, Task, TaskAssignee
 
 
-class MultiQSFilterMixin():
+class MultiQSFilterMixin:
     def filter_queryset(self, queryset):
         qs = super().filter_queryset(queryset)
         return qs._finalize()
-
 
 
 class TaskStatisticFilterSet(MultiQSFilterMixin, FilterSet):
@@ -34,107 +37,27 @@ class TaskStatisticFilterSet(MultiQSFilterMixin, FilterSet):
     cost_center = NumberFilter(method="filter_cost_center")
     rejected = NumberFilter(field_name="reports__rejected")
 
-
     def filter_has_reviewer(self, queryset, name, value):
         if not value:  # pragma: no cover
             return queryset
 
-        # reports in which user is customer assignee and responsible reviewer
-        reports_customer_assignee_is_reviewer = queryset.filter(
+        return queryset.filter(
             Q(
                 project__customer_id__in=CustomerAssignee.objects.filter(
                     is_reviewer=True, user_id=value
                 ).values("customer_id")
             )
-        ).exclude(
-            Q(
-                project_id__in=ProjectAssignee.objects.filter(
-                    is_reviewer=True
-                ).values("project_id")
-            )
             | Q(
-                id__in=TaskAssignee.objects.filter(is_reviewer=True).values(
-                    "task_id"
-                )
-            )
-        )
-
-        # reports in which user is project assignee and responsible reviewer
-        reports_project_assignee_is_reviewer = queryset.filter(
-            Q(
                 project_id__in=ProjectAssignee.objects.filter(
                     is_reviewer=True, user_id=value
                 ).values("project_id")
             )
-        ).exclude(
-            Q(
-                id__in=TaskAssignee.objects.filter(is_reviewer=True).values(
-                    "task_id"
-                )
-            )
-        )
-
-        # reports in which user task assignee and responsible reviewer
-        reports_task_assignee_is_reviewer = queryset.filter(
-            Q(
+            | Q(
                 id__in=TaskAssignee.objects.filter(
                     is_reviewer=True, user_id=value
                 ).values("task_id")
             )
         )
-
-        return (
-            reports_customer_assignee_is_reviewer
-            | reports_project_assignee_is_reviewer
-            | reports_task_assignee_is_reviewer
-        )
-
-    def filter_editable(self, queryset, name, value):
-        """Filter reports whether they are editable by current user.
-
-        When set to `1` filter all results to what is editable by current
-        user. If set to `0` to not editable.
-        """
-        user = self.request.user
-        assignee_filter = (
-            # avoid duplicates by using subqueries instead of joins
-            Q(reports__user__in=user.supervisees.values("id"))
-            | Q(
-                task_assignees__user=user,
-                task_assignees__is_reviewer=True,
-            )
-            | Q(
-                project__project_assignees__user=user,
-                project__project_assignees__is_reviewer=True,
-            )
-            | Q(
-                project__customer__customer_assignees__user=user,
-                project__customer__customer_assignees__is_reviewer=True,
-            )
-            | Q(reports__user=user)
-        )
-        unfinished_filter = Q(reports__verified_by__isnull=True)
-        editable_filter = assignee_filter & unfinished_filter
-
-        if value:  # editable
-            if user.is_superuser:
-                # superuser may edit all reports
-                return queryset
-            elif user.is_accountant:
-                return queryset.filter(unfinished_filter)
-            # only owner, reviewer or supervisor may change unverified reports
-            queryset = queryset.filter(editable_filter).distinct()
-
-            return queryset
-        else:  # not editable
-            if user.is_superuser:
-                # no reports which are not editable
-                return queryset.none()
-            elif user.is_accountant:
-                return queryset.exclude(unfinished_filter)
-
-            queryset = queryset.exclude(editable_filter)
-            return queryset
 
     def filter_cost_center(self, queryset, name, value):
         """
@@ -147,7 +70,6 @@ class TaskStatisticFilterSet(MultiQSFilterMixin, FilterSet):
             Q(cost_center=value)
             | Q(project__cost_center=value) & Q(cost_center__isnull=True)
         )
-
 
     class Meta:
         """Meta information for the task statistic filter set."""

--- a/timed/reports/serializers.py
+++ b/timed/reports/serializers.py
@@ -26,7 +26,7 @@ class MonthStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 class CustomerStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField()
     customer = relations.ResourceRelatedField(
-        source="task__project__customer", model=Customer, read_only=True
+        source="project__customer", model=Customer, read_only=True
     )
 
     included_serializers = {"customer": "timed.projects.serializers.CustomerSerializer"}
@@ -38,7 +38,7 @@ class CustomerStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 class ProjectStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField()
     project = relations.ResourceRelatedField(
-        source="task__project", model=Project, read_only=True
+        model=Project, read_only=True
     )
 
     included_serializers = {"project": "timed.projects.serializers.ProjectSerializer"}
@@ -49,9 +49,9 @@ class ProjectStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 
 class TaskStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField(read_only=True)
-    task = relations.ResourceRelatedField(model=Task, read_only=True)
+    project = relations.ResourceRelatedField(model=Project, read_only=True)
 
-    included_serializers = {"task": "timed.projects.serializers.TaskSerializer"}
+    included_serializers = {"project": "timed.projects.serializers.ProjectSerializer"}
 
     class Meta:
         resource_name = "task-statistics"

--- a/timed/reports/serializers.py
+++ b/timed/reports/serializers.py
@@ -1,6 +1,11 @@
 from django.contrib.auth import get_user_model
 from rest_framework_json_api import relations
-from rest_framework_json_api.serializers import DurationField, IntegerField, Serializer
+from rest_framework_json_api.serializers import (
+    CharField,
+    DurationField,
+    IntegerField,
+    Serializer,
+)
 
 from timed.projects.models import Customer, Project, Task
 from timed.serializers import TotalTimeRootMetaMixin
@@ -25,9 +30,7 @@ class MonthStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 
 class CustomerStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField()
-    customer = relations.ResourceRelatedField(
-        source="project__customer", model=Customer, read_only=True
-    )
+    name = CharField(read_only=True)
 
     included_serializers = {"customer": "timed.projects.serializers.CustomerSerializer"}
 
@@ -37,17 +40,15 @@ class CustomerStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
 
 class ProjectStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
     duration = DurationField()
-    project = relations.ResourceRelatedField(
-        model=Project, read_only=True
-    )
-
-    included_serializers = {"project": "timed.projects.serializers.ProjectSerializer"}
+    name = CharField()
 
     class Meta:
         resource_name = "project-statistics"
 
 
 class TaskStatisticSerializer(TotalTimeRootMetaMixin, Serializer):
+    name = CharField(read_only=True)
+    most_recent_remaining_effort = DurationField(read_only=True)
     duration = DurationField(read_only=True)
     project = relations.ResourceRelatedField(model=Project, read_only=True)
 

--- a/timed/reports/serializers.py
+++ b/timed/reports/serializers.py
@@ -7,7 +7,7 @@ from rest_framework_json_api.serializers import (
     Serializer,
 )
 
-from timed.projects.models import Customer, Project, Task
+from timed.projects.models import Project
 from timed.serializers import TotalTimeRootMetaMixin
 
 

--- a/timed/reports/tests/test_customer_statistic.py
+++ b/timed/reports/tests/test_customer_statistic.py
@@ -6,8 +6,8 @@ from rest_framework import status
 
 from timed.conftest import setup_customer_and_employment_status
 from timed.employment.factories import EmploymentFactory
-from timed.tracking.factories import ReportFactory
 from timed.projects.models import Customer
+from timed.tracking.factories import ReportFactory
 
 
 @pytest.mark.parametrize(
@@ -15,9 +15,9 @@ from timed.projects.models import Customer
     [
         (False, True, False, 1, status.HTTP_403_FORBIDDEN),
         (False, True, True, 1, status.HTTP_403_FORBIDDEN),
-        (True, False, False, 4, status.HTTP_200_OK),
-        (True, True, False, 4, status.HTTP_200_OK),
-        (True, True, True, 4, status.HTTP_200_OK),
+        (True, False, False, 3, status.HTTP_200_OK),
+        (True, True, False, 3, status.HTTP_200_OK),
+        (True, True, True, 3, status.HTTP_200_OK),
     ],
 )
 def test_customer_statistic_list(
@@ -55,17 +55,17 @@ def test_customer_statistic_list(
             {
                 "type": "customer-statistics",
                 "id": str(report.task.project.customer.id),
-                "attributes": {"duration": "03:00:00"},
-                "relationships": {
-                    "customer": {"data": {"id": str(report.task.project.customer.id), "type": "customers"}}
+                "attributes": {
+                    "duration": "03:00:00",
+                    "name": report.task.project.customer.name,
                 },
             },
             {
                 "type": "customer-statistics",
                 "id": str(report2.task.project.customer.id),
-                "attributes": {"duration": "04:00:00"},
-                "relationships": {
-                    "customer": {"data": {"id": str(report2.task.project.customer.id), "type": "customers"}}
+                "attributes": {
+                    "duration": "04:00:00",
+                    "name": report2.task.project.customer.name,
                 },
             },
         ]
@@ -76,7 +76,7 @@ def test_customer_statistic_list(
 @pytest.mark.parametrize(
     "is_employed, expected, status_code",
     [
-        (True, 5, status.HTTP_200_OK),
+        (True, 4, status.HTTP_200_OK),
         (False, 1, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -89,9 +89,7 @@ def test_customer_statistic_detail(
 
     url = reverse("customer-statistic-detail", args=[report.task.project.customer.id])
     with django_assert_num_queries(expected):
-        result = auth_client.get(
-            url, data={"ordering": "duration"}
-        )
+        result = auth_client.get(url, data={"ordering": "duration"})
     assert result.status_code == status_code
     if status_code == status.HTTP_200_OK:
         json = result.json()

--- a/timed/reports/tests/test_customer_statistic.py
+++ b/timed/reports/tests/test_customer_statistic.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from timed.conftest import setup_customer_and_employment_status
 from timed.employment.factories import EmploymentFactory
 from timed.tracking.factories import ReportFactory
+from timed.projects.models import Customer
 
 
 @pytest.mark.parametrize(
@@ -56,12 +57,7 @@ def test_customer_statistic_list(
                 "id": str(report.task.project.customer.id),
                 "attributes": {"duration": "03:00:00"},
                 "relationships": {
-                    "customer": {
-                        "data": {
-                            "id": str(report.task.project.customer.id),
-                            "type": "customers",
-                        }
-                    }
+                    "customer": {"data": {"id": str(report.task.project.customer.id), "type": "customers"}}
                 },
             },
             {
@@ -69,17 +65,11 @@ def test_customer_statistic_list(
                 "id": str(report2.task.project.customer.id),
                 "attributes": {"duration": "04:00:00"},
                 "relationships": {
-                    "customer": {
-                        "data": {
-                            "id": str(report2.task.project.customer.id),
-                            "type": "customers",
-                        }
-                    }
+                    "customer": {"data": {"id": str(report2.task.project.customer.id), "type": "customers"}}
                 },
             },
         ]
         assert json["data"] == expected_data
-        assert len(json["included"]) == 2
         assert json["meta"]["total-time"] == "07:00:00"
 
 
@@ -100,7 +90,7 @@ def test_customer_statistic_detail(
     url = reverse("customer-statistic-detail", args=[report.task.project.customer.id])
     with django_assert_num_queries(expected):
         result = auth_client.get(
-            url, data={"ordering": "duration", "include": "customer"}
+            url, data={"ordering": "duration"}
         )
     assert result.status_code == status_code
     if status_code == status.HTTP_200_OK:

--- a/timed/reports/tests/test_customer_statistic.py
+++ b/timed/reports/tests/test_customer_statistic.py
@@ -6,7 +6,6 @@ from rest_framework import status
 
 from timed.conftest import setup_customer_and_employment_status
 from timed.employment.factories import EmploymentFactory
-from timed.projects.models import Customer
 from timed.tracking.factories import ReportFactory
 
 

--- a/timed/reports/tests/test_project_statistic.py
+++ b/timed/reports/tests/test_project_statistic.py
@@ -42,7 +42,7 @@ def test_project_statistic_list(
     url = reverse("project-statistic-list")
     with django_assert_num_queries(expected):
         result = auth_client.get(
-            url, data={"ordering": "duration", "include": "project,project.customer"}
+            url, data={"ordering": "duration", "include": "project"}
         )
     assert result.status_code == status_code
 
@@ -71,5 +71,5 @@ def test_project_statistic_list(
             },
         ]
         assert json["data"] == expected_json
-        assert len(json["included"]) == 4
+        assert len(json["included"]) == 2
         assert json["meta"]["total-time"] == "07:00:00"

--- a/timed/reports/tests/test_task_statistic.py
+++ b/timed/reports/tests/test_task_statistic.py
@@ -47,8 +47,8 @@ def test_task_statistic_list(
         result = auth_client.get(
             url,
             data={
-                "ordering": "task__name",
-                "include": "task,task.project,task.project.customer",
+                "ordering": "name",
+                "include": "project,project.customer",
             },
         )
     assert result.status_code == status_code
@@ -61,7 +61,7 @@ def test_task_statistic_list(
                 "id": str(task_test.id),
                 "attributes": {"duration": "03:00:00"},
                 "relationships": {
-                    "task": {"data": {"id": str(task_test.id), "type": "tasks"}}
+                    "project": {"data": {"id": str(task_test.project.id), "type": "projects"}}
                 },
             },
             {
@@ -69,10 +69,10 @@ def test_task_statistic_list(
                 "id": str(task_z.id),
                 "attributes": {"duration": "02:00:00"},
                 "relationships": {
-                    "task": {"data": {"id": str(task_z.id), "type": "tasks"}}
+                    "project": {"data": {"id": str(task_z.project.id), "type": "projects"}}
                 },
             },
         ]
         assert json["data"] == expected_json
-        assert len(json["included"]) == 6
+        assert len(json["included"]) == 4
         assert json["meta"]["total-time"] == "05:00:00"

--- a/timed/reports/tests/test_task_statistic.py
+++ b/timed/reports/tests/test_task_statistic.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, timedelta
 
 import pytest
 from django.urls import reverse
@@ -59,20 +59,75 @@ def test_task_statistic_list(
             {
                 "type": "task-statistics",
                 "id": str(task_test.id),
-                "attributes": {"duration": "03:00:00"},
+                "attributes": {
+                    "duration": "03:00:00",
+                    "name": str(task_test.name),
+                    "most-recent-remaining-effort": None,
+                },
                 "relationships": {
-                    "project": {"data": {"id": str(task_test.project.id), "type": "projects"}}
+                    "project": {
+                        "data": {"id": str(task_test.project.id), "type": "projects"}
+                    }
                 },
             },
             {
                 "type": "task-statistics",
                 "id": str(task_z.id),
-                "attributes": {"duration": "02:00:00"},
+                "attributes": {
+                    "duration": "02:00:00",
+                    "name": str(task_z.name),
+                    "most-recent-remaining-effort": None,
+                },
                 "relationships": {
-                    "project": {"data": {"id": str(task_z.project.id), "type": "projects"}}
+                    "project": {
+                        "data": {"id": str(task_z.project.id), "type": "projects"}
+                    }
                 },
             },
         ]
         assert json["data"] == expected_json
-        assert len(json["included"]) == 4
         assert json["meta"]["total-time"] == "05:00:00"
+
+
+@pytest.mark.parametrize(
+    "filter, expected_result",
+    [("from_date", 5), ("customer", 3)],
+)
+def test_task_statistic_filtered(
+    auth_client,
+    filter,
+    expected_result,
+):
+
+    user = auth_client.user
+    setup_customer_and_employment_status(
+        user=user,
+        is_assignee=True,
+        is_customer=True,
+        is_employed=True,
+        is_external=False,
+    )
+
+    task_z = TaskFactory.create(name="Z")
+    task_test = TaskFactory.create(name="Test")
+
+    ReportFactory.create(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
+    ReportFactory.create(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
+    ReportFactory.create(duration=timedelta(hours=3), date="2022-09-01", task=task_z)
+
+    filter_values = {
+        "from_date": "2022-08-20",  # last two reports
+        "customer": str(task_test.project.customer.pk),  # first two
+    }
+    the_filter = {filter: filter_values[filter]}
+
+    url = reverse("task-statistic-list")
+    result = auth_client.get(
+        url,
+        data={"ordering": "name", "include": "project,project.customer", **the_filter},
+    )
+    assert result.status_code == status.HTTP_200_OK
+
+    json = result.json()
+
+    assert json["meta"]["total-time"] == f"{expected_result:02}:00:00"

--- a/timed/reports/views.py
+++ b/timed/reports/views.py
@@ -86,8 +86,6 @@ class CustomerStatisticViewSet(AggregateQuerysetMixin, ReadOnlyModelViewSet):
     def get_queryset(self):
         queryset = MultiQS(
             start=Customer,
-            #            Task.objects.all(),
-            #            Report.objects.all(),
             annotations={
                 "customer_id": F("pk"),
                 "name": F("name"),


### PR DESCRIPTION
When filtering statistics, we face the problem that we want to
have a list of all tasks, and count the reported hours. Due to the
way Django works, the Sum of reported hours would trigger an (unfiltered)
subquery or Join, so our filters don't apply.

Therefore, we now have a "split" pseudo-queryset, which contains separate
querysets for tasks and reports. It then applies the filters to EITHER
of the querysets as needed (depending on prefix), then combines them
at the end of the filtering phase, using a subquery.
