### PR TITLE
fix(tracking): fix absence for users with multiple employments

### DIFF
--- a/timed/tracking/models.py
+++ b/timed/tracking/models.py
@@ -129,21 +129,6 @@ class Report(models.Model):
         indexes = [models.Index(fields=["date"])]
 
 
-class AbsenceManager(models.Manager):
-    def get_queryset(self):
-        from timed.employment.models import PublicHoliday
-
-        queryset = super().get_queryset()
-        queryset = queryset.exclude(
-            date__in=models.Subquery(
-                PublicHoliday.objects.filter(
-                    location__employments__user=models.OuterRef("user")
-                ).values("date")
-            )
-        )
-        return queryset
-
-
 class Absence(models.Model):
     """Absence model.
 
@@ -159,7 +144,6 @@ class Absence(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="absences"
     )
-    objects = AbsenceManager()
 
     def calculate_duration(self, employment):
         """


### PR DESCRIPTION
1. fix: move the PublicHoliday exclusion from absence object manager   
to AbsenceViewSet get_queryset()

2. fix: only exclude public holidays from the current employment.
This was an issue for users with multiple employments (past and current) at different locations,
as locations may have different public holidays.   