### PR TITLE
fix(tracking): fix remaining effort check when creating report

### DIFF
--- a/timed/tracking/serializers.py
+++ b/timed/tracking/serializers.py
@@ -136,14 +136,6 @@ class ReportSerializer(TotalTimeRootMetaMixin, ModelSerializer):
 
         return value
 
-    def validate_remaining_effort(self, value):
-        """Only update remaining effort when tracking is active on the corresponding project."""
-        if not self.instance.task.project.remaining_effort_tracking:
-            raise ValidationError(
-                "Remaining effort tracking is not active on this project!"
-            )
-        return value
-
     def validate(self, data):
         """
         Validate that verified by is only set by reviewer or superuser.
@@ -152,6 +144,8 @@ class ReportSerializer(TotalTimeRootMetaMixin, ModelSerializer):
         needs review.
 
         External employees with manager or reviewer role may not create reports.
+
+        Check if remaing effort tracking is active on the corresponding project.
         """
 
         user = self.context["request"].user
@@ -180,6 +174,12 @@ class ReportSerializer(TotalTimeRootMetaMixin, ModelSerializer):
                 )
             ).exists()
         )
+
+        # check if remaining effort tracking is active on the corresponding project
+        if not task.project.remaining_effort_tracking and data.get("remaining_effort"):
+            raise ValidationError(
+                "Remaining effort tracking is not active on this project!"
+            )
 
         if new_verified_by != current_verified_by:
             if not is_reviewer:

--- a/timed/tracking/tests/test_report.py
+++ b/timed/tracking/tests/test_report.py
@@ -1854,6 +1854,54 @@ def test_report_set_remaining_effort(
     assert response.status_code == expected
 
 
+@pytest.mark.parametrize(
+    "remaining_effort_active, expected",
+    [
+        (True, status.HTTP_201_CREATED),
+        (False, status.HTTP_400_BAD_REQUEST),
+    ],
+)
+def test_report_create_remaining_effort(
+    internal_employee_client,
+    report_factory,
+    project_factory,
+    task_factory,
+    remaining_effort_active,
+    expected,
+):
+    user = internal_employee_client.user
+    project = project_factory.create(
+        billed=True, remaining_effort_tracking=remaining_effort_active
+    )
+    task = task_factory.create(project=project)
+
+    data = {
+        "data": {
+            "type": "reports",
+            "id": None,
+            "attributes": {
+                "comment": "foo",
+                "duration": "00:15:00",
+                "date": "2022-02-01",
+                "remaining_effort": "01:00:00",
+            },
+            "relationships": {
+                "task": {"data": {"type": "tasks", "id": task.id}},
+            },
+        }
+    }
+
+    url = reverse("report-list")
+
+    response = internal_employee_client.post(url, data)
+    assert response.status_code == expected
+
+    if expected == status.HTTP_201_CREATED:
+        json = response.json()
+        assert json["data"]["relationships"]["user"]["data"]["id"] == str(user.id)
+        assert json["data"]["relationships"]["task"]["data"]["id"] == str(task.id)
+
+
 def test_report_remaining_effort_total(
     internal_employee_client,
     report_factory,


### PR DESCRIPTION
Check if remaining effort tracking is active on the corresponding project when creating a new report as well.
Previously the check only worked when updating a report, but not when creating one (no instance when creating a new report).