### PR TITLE
fix: add missing rejected field to ReportIntersectionSerializer

### DIFF
--- a/timed/tracking/serializers.py
+++ b/timed/tracking/serializers.py
@@ -303,6 +303,7 @@ class ReportIntersectionSerializer(Serializer):
     not_billable = SerializerMethodField()
     billed = SerializerMethodField()
     verified = SerializerMethodField()
+    rejected = SerializerMethodField()
 
     def _intersection(self, instance, field, model=None):
         """Get intersection of given field.
@@ -355,6 +356,9 @@ class ReportIntersectionSerializer(Serializer):
         )
         instance["queryset"] = queryset
         return self._intersection(instance, "verified")
+
+    def get_rejected(self, instance):
+        return self._intersection(instance, "rejected")
 
     def get_root_meta(self, resource, many):
         """Add number of results to meta."""

--- a/timed/tracking/tests/test_report.py
+++ b/timed/tracking/tests/test_report.py
@@ -83,6 +83,7 @@ def test_report_intersection_full(
                 "verified": False,
                 "review": False,
                 "billed": False,
+                "rejected": False,
             },
             "relationships": {
                 "customer": {
@@ -129,6 +130,7 @@ def test_report_intersection_partial(
                 "verified": None,
                 "review": None,
                 "billed": None,
+                "rejected": False,
             },
             "relationships": {
                 "customer": {"data": None},
@@ -173,6 +175,7 @@ def test_report_intersection_accountant_editable(
                 "verified": False,
                 "review": True,
                 "billed": None,
+                "rejected": False,
             },
             "relationships": {
                 "customer": {"data": None},
@@ -217,6 +220,7 @@ def test_report_intersection_accountant_not_editable(
                 "verified": None,
                 "review": None,
                 "billed": None,
+                "rejected": None,
             },
             "relationships": {
                 "customer": {"data": None},


### PR DESCRIPTION
Just added missing field `rejected` to the Serializer