### PR TITLE
feat(filters): add number multi value filter

### DIFF
--- a/timed/projects/filters.py
+++ b/timed/projects/filters.py
@@ -30,6 +30,7 @@ class ProjectFilterSet(FilterSet):
     archived = NumberFilter(field_name="archived")
     has_manager = NumberFilter(method="filter_has_manager")
     has_reviewer = NumberFilter(method="filter_has_reviewer")
+    customer = NumberInFilter(field_name="customer")
 
     def filter_has_manager(self, queryset, name, value):
         if not value:  # pragma: no cover
@@ -115,6 +116,7 @@ class TaskFilterSet(FilterSet):
 
     my_most_frequent = MyMostFrequentTaskFilter()
     archived = NumberFilter(field_name="archived")
+    project = NumberInFilter(field_name="project")
 
     class Meta:
         """Meta information for the task filter set."""

--- a/timed/projects/tests/test_project.py
+++ b/timed/projects/tests/test_project.py
@@ -154,6 +154,20 @@ def test_project_filter(internal_employee_client):
     assert len(json["data"]) == 1
 
 
+def test_project_multi_number_value_filter(internal_employee_client):
+    proj1, proj2, *_ = ProjectFactory.create_batch(4)
+
+    url = reverse("project-list")
+
+    response = internal_employee_client.get(
+        url, {"customer": (",").join([str(proj1.customer.id), str(proj2.customer.id)])}
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    json = response.json()
+    assert len(json["data"]) == 2
+
+
 def test_project_update_billed_flag(internal_employee_client, report_factory):
     report = report_factory.create()
     project = report.task.project

--- a/timed/projects/tests/test_task.py
+++ b/timed/projects/tests/test_task.py
@@ -229,3 +229,17 @@ def test_task_list_no_employment(auth_client, is_customer, customer_visible, exp
 
     json = response.json()
     assert len(json["data"]) == expected
+
+
+def test_task_multi_number_value_filter(internal_employee_client):
+    task1, task2, *_ = TaskFactory.create_batch(4)
+
+    url = reverse("task-list")
+
+    response = internal_employee_client.get(
+        url, {"project": (",").join([str(task1.project.id), str(task2.project.id)])}
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    json = response.json()
+    assert len(json["data"]) == 2


### PR DESCRIPTION
We were in the need to pass multiple filter values for the `tasks` and `projects` endpoints. Further details regarding it's usage can be found here: https://github.com/adfinis/timed-frontend/pull/823