### PR TITLE
feat: empty sums in correcr ordering

### DIFF
--- a/timed/reports/filters.py
+++ b/timed/reports/filters.py
@@ -1,4 +1,5 @@
-from django.db.models import F, Q, Sum
+from django.db.models import DurationField, F, Q, Sum, Value
+from django.db.models.functions import Coalesce
 from django_filters.rest_framework import (
     BaseInFilter,
     DateFilter,
@@ -82,7 +83,11 @@ class StatisticFiltersetBase:
         duration_ref = self._refs["reports_ref"] + "__duration"
 
         full_qs = qs._base.annotate(
-            duration=Sum(duration_ref, filter=qs._agg_filters), pk=F("id")
+            duration=Coalesce(
+                Sum(duration_ref, filter=qs._agg_filters),
+                Value("00:00:00", DurationField(null=False)),
+            ),
+            pk=F("id"),
         )
         result = full_qs.values()
         # Useful for QS debugging

--- a/timed/reports/tests/test_customer_statistic.py
+++ b/timed/reports/tests/test_customer_statistic.py
@@ -75,16 +75,16 @@ def test_customer_statistic_list(
             },
         ]
         if third_customer:
-            expected_data.append(
+            expected_data = [
                 {
                     "type": "customer-statistics",
                     "id": str(third_customer.pk),
                     "attributes": {
-                        "duration": None,
+                        "duration": "00:00:00",
                         "name": third_customer.name,
                     },
                 }
-            )
+            ] + expected_data
         assert json["data"] == expected_data
         assert json["meta"]["total-time"] == "07:00:00"
 


### PR DESCRIPTION
The statistics should report zero hours instead of NULL. This makes the ordering of data actually work as expected