### PR TITLE
fix(tracking): don't send emails when updating own rejected reports

### DIFF
--- a/timed/tracking/serializers.py
+++ b/timed/tracking/serializers.py
@@ -131,7 +131,9 @@ class ReportSerializer(TotalTimeRootMetaMixin, ModelSerializer):
         """Only reviewers are allowed to change rejected field."""
         if self.instance is not None:
             user = self.context["request"].user
-            if not user.is_reviewer and (self.instance.rejected != value):
+            if (
+                not user.is_reviewer or self.instance.user == user
+            ) and self.instance.rejected != value:
                 raise ValidationError(_("Only reviewers may reject reports."))
 
         return value


### PR DESCRIPTION
Don't send emails when updating anything besides task on a rejected report that the user owns.
Updating the task on a rejected report should still automatically unreject the report.

Fixes #963 