### PR TITLE
refactor(redmine): remove spent hours from redmine bot

### DIFF
--- a/timed/redmine/management/commands/update_project_expenditure.py
+++ b/timed/redmine/management/commands/update_project_expenditure.py
@@ -44,11 +44,6 @@ class Command(BaseCommand):
                 if project.estimated_time
                 else 0.0
             )
-            total_spent_hours = (
-                project.total_hours.total_seconds() / 3600
-                if project.total_hours
-                else 0.0
-            )
             try:
                 issue = redmine.issue.get(project.redmine_project.issue_id)
             except redminelib.exceptions.BaseRedmineError as e:
@@ -69,10 +64,6 @@ class Command(BaseCommand):
 
             # fields not active in Redmine projects settings won't be saved
             issue.custom_fields = [
-                {
-                    "id": settings.REDMINE_SPENTHOURS_FIELD,
-                    "value": total_spent_hours,
-                },
                 {
                     "id": settings.REDMINE_AMOUNT_OFFERED_FIELD,
                     "value": amount_offered,
@@ -95,6 +86,6 @@ class Command(BaseCommand):
 
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Updating Redmine issue {project.redmine_project.issue_id} with total spent hours {total_spent_hours}, estimated time {estimated_hours}, amount offered {amount_offered}, amount invoiced {amount_invoiced}"
+                    f"Updating Redmine issue {project.redmine_project.issue_id} with estimated time {estimated_hours}, amount offered {amount_offered}, amount invoiced {amount_invoiced}"
                 )
             )

--- a/timed/redmine/tests/test_update_project_expenditure.py
+++ b/timed/redmine/tests/test_update_project_expenditure.py
@@ -18,7 +18,7 @@ def test_update_project_expenditure(
     redmine_class = mocker.patch("redminelib.Redmine")
     redmine_class.return_value = redmine_instance
 
-    report = report_factory(duration=datetime.timedelta(hours=4))
+    report = report_factory()
     project = report.task.project
     project.estimated_time = datetime.timedelta(hours=10)
     project.amount_offered = amount_offered
@@ -33,14 +33,12 @@ def test_update_project_expenditure(
     if not pretend:
         redmine_instance.issue.get.assert_called_once_with(1000)
         assert issue.estimated_hours == project.estimated_time.total_seconds() / 3600
-        assert issue.custom_fields[0]["value"] == report.duration.total_seconds() / 3600
-        assert issue.custom_fields[1]["value"] == offered
-        assert issue.custom_fields[2]["value"] == project.amount_invoiced.amount
+        assert issue.custom_fields[0]["value"] == offered
+        assert issue.custom_fields[1]["value"] == project.amount_invoiced.amount
         issue.save.assert_called_once_with()
     else:
         out, _ = capsys.readouterr()
         assert "Redmine issue 1000" in out
-        assert f"total spent hours {report.duration.total_seconds() / 3600}" in out
         assert f"amount offered {offered}" in out
         assert f"amount invoiced {project.amount_invoiced.amount}" in out
 


### PR DESCRIPTION
Remove spent hours from update_project_expenditure bot as redmine_report already does it.