### PR TITLE
fix(redmine): convert Decimal objects to floats

### DIFF
--- a/timed/redmine/management/commands/update_project_expenditure.py
+++ b/timed/redmine/management/commands/update_project_expenditure.py
@@ -56,11 +56,11 @@ class Command(BaseCommand):
             issue.estimated_hours = estimated_hours
 
             amount_offered = (
-                project.amount_offered and project.amount_offered.amount
-            ) or "0.00"
+                project.amount_offered and float(project.amount_offered.amount)
+            ) or 0.0
             amount_invoiced = (
-                project.amount_invoiced and project.amount_invoiced.amount
-            ) or "0.00"
+                project.amount_invoiced and float(project.amount_invoiced.amount)
+            ) or 0.0
 
             # fields not active in Redmine projects settings won't be saved
             issue.custom_fields = [

--- a/timed/redmine/tests/test_update_project_expenditure.py
+++ b/timed/redmine/tests/test_update_project_expenditure.py
@@ -28,7 +28,7 @@ def test_update_project_expenditure(
 
     call_command("update_project_expenditure", pretend=pretend)
 
-    offered = (project.amount_offered and project.amount_offered.amount) or "0.00"
+    offered = (project.amount_offered and project.amount_offered.amount) or 0.0
 
     if not pretend:
         redmine_instance.issue.get.assert_called_once_with(1000)


### PR DESCRIPTION
Decimal objects are not JSON serializable, therefore we have to convert them to float.